### PR TITLE
Improve prompt to actually reference the stats

### DIFF
--- a/src/weekly_strava_stats/utils/message_builder.py
+++ b/src/weekly_strava_stats/utils/message_builder.py
@@ -139,7 +139,7 @@ class MessageBuilder:
         prompt_config = random.choice(prompt_configs)
         author, user_prompt, language = prompt_config.split(';')
 
-        full_prompt = f"I provide you the aggregated running stats of our running group and I want you to come up with a quote to comment on it that sounds like it's from {author} {user_prompt}. Just reply with the quote in {language}, no explanation or quotation marks around it."
+        full_prompt = f"I provide you the aggregated running stats of our running group and I want you to come up with a quote to comment on it that sounds like it's from {author} {user_prompt}. Just reply with the quote in {language}, no explanation or quotation marks around it. Reference numbers."
         full_prompt += f"\n\n{original_message}"
 
         groq_client = Groq(api_key=self.groq_api_key)


### PR DESCRIPTION
This PR improves the prompt to actually reference the number. With some user prompts, that worked well before and with some it didn't.
Previous to this PR, there were many quotes like this:

> Sheldon Cooper: I'm beginning to think the only thing you people are accomplishing with these running stats is a futile attempt to defy the inevitable decline of human physiology, all while unnecessarily subjecting yourselves to exhaustion and blisters.